### PR TITLE
Fix tagging

### DIFF
--- a/build_push.sh
+++ b/build_push.sh
@@ -73,14 +73,19 @@ function is_not_dev_version {
 function get_tags {
   IMAGE_TAGS=(
     $NAMESPACE/$IMAGE:$VERSION
-    $NAMESPACE/$IMAGE:$MAJOR_VERSION.$MINOR_VERSION
   )
 
   if is_not_dev_version;
   then
-    IMAGE_TAGS+=($NAMESPACE/$IMAGE:$MAJOR_VERSION)
+    IMAGE_TAGS+=(
+      $NAMESPACE/$IMAGE:$MAJOR_VERSION
+      $NAMESPACE/$IMAGE:$MAJOR_VERSION.$MINOR_VERSION
+    )
   else
-    IMAGE_TAGS+=($NAMESPACE/$IMAGE:dev)
+    IMAGE_TAGS+=(
+      $NAMESPACE/$IMAGE:dev
+      $NAMESPACE/$IMAGE:$MAJOR_VERSION.$MINOR_VERSION-dev
+    )
   fi
 }
 
@@ -109,7 +114,7 @@ function build_and_tag {
        " and $NAMESPACE/$IMAGE:$VERSION"
   # Create Dockerfile from template.
   sed -e s/{{VERSION}}/$VERSION/ \
-      -e s/{{NAMESPACE}}/$NAMESPACE/ \
+      -e s/{{NAMESPACE}}/${NAMESPACE//\//\\/}/ \
       $REPO_ROOT/$DIRECTORY/Dockerfile.template > \
       $REPO_ROOT/$DIRECTORY/Dockerfile
 
@@ -118,7 +123,7 @@ function build_and_tag {
 
   for i in "${IMAGE_TAGS[@]}"
   do
-    docker tag $NAMESPACE/$IMAGE $i
+    docker tag -f $NAMESPACE/$IMAGE $i
   done
 
   # Check the Dart version in the image.


### PR DESCRIPTION
Okay this fixes any and all tagging.

Below are runs of the script pushing to my local registry.

```
~/Documents/GitHub/dart_docker$ ./build_push.sh x.x.x.x:5000/dolmstead 1.12.1
~/Documents/GitHub/dart_docker$ docker images

REPOSITORY                                                      TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
x.x.x.x:5000/dolmstead/dart-hello          1                   7598abb13558        2 minutes ago       184.7 MB
x.x.x.x:5000/dolmstead/dart-hello          1.12                7598abb13558        2 minutes ago       184.7 MB
x.x.x.x:5000/dolmstead/dart-hello          1.12.1              7598abb13558        2 minutes ago       184.7 MB
x.x.x.x:5000/dolmstead/dart-hello          latest              7598abb13558        2 minutes ago       184.7 MB
x.x.x.x:5000/dolmstead/dart-runtime        latest              26e06efbe443        2 minutes ago       184.3 MB
x.x.x.x:5000/dolmstead/dart-runtime        1                   26e06efbe443        2 minutes ago       184.3 MB
x.x.x.x:5000/dolmstead/dart-runtime        1.12                26e06efbe443        2 minutes ago       184.3 MB
x.x.x.x:5000/dolmstead/dart-runtime        1.12.1              26e06efbe443        2 minutes ago       184.3 MB
x.x.x.x:5000/dolmstead/dart-runtime-base   1                   91681a1b882d        2 minutes ago       184.3 MB
x.x.x.x:5000/dolmstead/dart-runtime-base   1.12                91681a1b882d        2 minutes ago       184.3 MB
x.x.x.x:5000/dolmstead/dart-runtime-base   1.12.1              91681a1b882d        2 minutes ago       184.3 MB
x.x.x.x:5000/dolmstead/dart-runtime-base   latest              91681a1b882d        2 minutes ago       184.3 MB
x.x.x.x:5000/dolmstead/dart                1                   816c55252994        2 minutes ago       184.3 MB
x.x.x.x:5000/dolmstead/dart                1.12                816c55252994        2 minutes ago       184.3 MB
x.x.x.x:5000/dolmstead/dart                1.12.1              816c55252994        2 minutes ago       184.3 MB
x.x.x.x:5000/dolmstead/dart                latest              816c55252994        2 minutes ago       184.3 MB
google/debian                                                   wheezy              11971b6377ef        11 months ago       88.23 MB

~/Documents/GitHub/dart_docker$ ./build_push.sh x.x.x.x:5000/dolmstead 1.13.0
~/Documents/GitHub/dart_docker$ docker images

REPOSITORY                                                      TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
x.x.x.x:5000/dolmstead/dart-hello          1.13                d68104607964        2 minutes ago       181.1 MB
x.x.x.x:5000/dolmstead/dart-hello          1.13.0              d68104607964        2 minutes ago       181.1 MB
x.x.x.x:5000/dolmstead/dart-hello          latest              d68104607964        2 minutes ago       181.1 MB
x.x.x.x:5000/dolmstead/dart-hello          1                   d68104607964        2 minutes ago       181.1 MB
x.x.x.x:5000/dolmstead/dart-runtime        latest              2e4bd918e50a        2 minutes ago       180.7 MB
x.x.x.x:5000/dolmstead/dart-runtime        1                   2e4bd918e50a        2 minutes ago       180.7 MB
x.x.x.x:5000/dolmstead/dart-runtime        1.13                2e4bd918e50a        2 minutes ago       180.7 MB
x.x.x.x:5000/dolmstead/dart-runtime        1.13.0              2e4bd918e50a        2 minutes ago       180.7 MB
x.x.x.x:5000/dolmstead/dart-runtime-base   1.13                35cf4c74f81f        2 minutes ago       180.7 MB
x.x.x.x:5000/dolmstead/dart-runtime-base   1.13.0              35cf4c74f81f        2 minutes ago       180.7 MB
x.x.x.x:5000/dolmstead/dart-runtime-base   latest              35cf4c74f81f        2 minutes ago       180.7 MB
x.x.x.x:5000/dolmstead/dart-runtime-base   1                   35cf4c74f81f        2 minutes ago       180.7 MB
x.x.x.x:5000/dolmstead/dart                1                   3c7478778e5c        2 minutes ago       180.7 MB
x.x.x.x:5000/dolmstead/dart                1.13                3c7478778e5c        2 minutes ago       180.7 MB
x.x.x.x:5000/dolmstead/dart                1.13.0              3c7478778e5c        2 minutes ago       180.7 MB
x.x.x.x:5000/dolmstead/dart                latest              3c7478778e5c        2 minutes ago       180.7 MB
<none>                                                          <none>              2a931e6cfeba        8 minutes ago       88.23 MB
<none>                                                          <none>              9bd2b53571fc        10 minutes ago      88.23 MB
<none>                                                          <none>              c635b21e7f12        13 minutes ago      88.23 MB
x.x.x.x:5000/dolmstead/dart-hello          1.12                7598abb13558        20 minutes ago      184.7 MB
x.x.x.x:5000/dolmstead/dart-hello          1.12.1              7598abb13558        20 minutes ago      184.7 MB
x.x.x.x:5000/dolmstead/dart-runtime        1.12                26e06efbe443        20 minutes ago      184.3 MB
x.x.x.x:5000/dolmstead/dart-runtime        1.12.1              26e06efbe443        20 minutes ago      184.3 MB
x.x.x.x:5000/dolmstead/dart-runtime-base   1.12.1              91681a1b882d        20 minutes ago      184.3 MB
x.x.x.x:5000/dolmstead/dart-runtime-base   1.12                91681a1b882d        20 minutes ago      184.3 MB
x.x.x.x:5000/dolmstead/dart                1.12                816c55252994        20 minutes ago      184.3 MB
x.x.x.x:5000/dolmstead/dart                1.12.1              816c55252994        20 minutes ago      184.3 MB
google/debian                                                   wheezy              11971b6377ef        11 months ago       88.23 MB

~/Documents/GitHub/dart_docker$ ./build_push.sh x.x.x.x:5000/dolmstead 1.14.0-dev.7.1
~/Documents/GitHub/dart_docker$ docker images

REPOSITORY                                                      TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
x.x.x.x:5000/dolmstead/dart-hello          1.14-dev            edcdacb90157        2 minutes ago       181.2 MB
x.x.x.x:5000/dolmstead/dart-hello          1.14.0-dev.7.1      edcdacb90157        2 minutes ago       181.2 MB
x.x.x.x:5000/dolmstead/dart-hello          dev                 edcdacb90157        2 minutes ago       181.2 MB
x.x.x.x:5000/dolmstead/dart-hello          latest              edcdacb90157        2 minutes ago       181.2 MB
x.x.x.x:5000/dolmstead/dart-runtime        dev                 e69ee817d48a        3 minutes ago       180.8 MB
x.x.x.x:5000/dolmstead/dart-runtime        latest              e69ee817d48a        3 minutes ago       180.8 MB
x.x.x.x:5000/dolmstead/dart-runtime        1.14-dev            e69ee817d48a        3 minutes ago       180.8 MB
x.x.x.x:5000/dolmstead/dart-runtime        1.14.0-dev.7.1      e69ee817d48a        3 minutes ago       180.8 MB
x.x.x.x:5000/dolmstead/dart-runtime-base   dev                 0c07b34f02e6        3 minutes ago       180.8 MB
x.x.x.x:5000/dolmstead/dart-runtime-base   latest              0c07b34f02e6        3 minutes ago       180.8 MB
x.x.x.x:5000/dolmstead/dart-runtime-base   1.14-dev            0c07b34f02e6        3 minutes ago       180.8 MB
x.x.x.x:5000/dolmstead/dart-runtime-base   1.14.0-dev.7.1      0c07b34f02e6        3 minutes ago       180.8 MB
x.x.x.x:5000/dolmstead/dart                dev                 e8ea62f91fc3        3 minutes ago       180.8 MB
x.x.x.x:5000/dolmstead/dart                latest              e8ea62f91fc3        3 minutes ago       180.8 MB
x.x.x.x:5000/dolmstead/dart                1.14-dev            e8ea62f91fc3        3 minutes ago       180.8 MB
x.x.x.x:5000/dolmstead/dart                1.14.0-dev.7.1      e8ea62f91fc3        3 minutes ago       180.8 MB
<none>                                                          <none>              88da0e53dacc        10 minutes ago      88.23 MB
<none>                                                          <none>              ee69bc37fb43        17 minutes ago      88.23 MB
x.x.x.x:5000/dolmstead/dart-hello          1.13.0              d68104607964        22 minutes ago      181.1 MB
x.x.x.x:5000/dolmstead/dart-hello          1                   d68104607964        22 minutes ago      181.1 MB
x.x.x.x:5000/dolmstead/dart-hello          1.13                d68104607964        22 minutes ago      181.1 MB
x.x.x.x:5000/dolmstead/dart-runtime        1                   2e4bd918e50a        22 minutes ago      180.7 MB
x.x.x.x:5000/dolmstead/dart-runtime        1.13                2e4bd918e50a        22 minutes ago      180.7 MB
x.x.x.x:5000/dolmstead/dart-runtime        1.13.0              2e4bd918e50a        22 minutes ago      180.7 MB
x.x.x.x:5000/dolmstead/dart-runtime-base   1.13                35cf4c74f81f        22 minutes ago      180.7 MB
x.x.x.x:5000/dolmstead/dart-runtime-base   1.13.0              35cf4c74f81f        22 minutes ago      180.7 MB
x.x.x.x:5000/dolmstead/dart-runtime-base   1                   35cf4c74f81f        22 minutes ago      180.7 MB
x.x.x.x:5000/dolmstead/dart                1.13                3c7478778e5c        22 minutes ago      180.7 MB
x.x.x.x:5000/dolmstead/dart                1.13.0              3c7478778e5c        22 minutes ago      180.7 MB
x.x.x.x:5000/dolmstead/dart                1                   3c7478778e5c        22 minutes ago      180.7 MB
<none>                                                          <none>              2a931e6cfeba        28 minutes ago      88.23 MB
<none>                                                          <none>              9bd2b53571fc        30 minutes ago      88.23 MB
<none>                                                          <none>              c635b21e7f12        33 minutes ago      88.23 MB
x.x.x.x:5000/dolmstead/dart-hello          1.12                7598abb13558        39 minutes ago      184.7 MB
x.x.x.x:5000/dolmstead/dart-hello          1.12.1              7598abb13558        39 minutes ago      184.7 MB
x.x.x.x:5000/dolmstead/dart-runtime        1.12.1              26e06efbe443        40 minutes ago      184.3 MB
x.x.x.x:5000/dolmstead/dart-runtime        1.12                26e06efbe443        40 minutes ago      184.3 MB
x.x.x.x:5000/dolmstead/dart-runtime-base   1.12.1              91681a1b882d        40 minutes ago      184.3 MB
x.x.x.x:5000/dolmstead/dart-runtime-base   1.12                91681a1b882d        40 minutes ago      184.3 MB
x.x.x.x:5000/dolmstead/dart                1.12.1              816c55252994        40 minutes ago      184.3 MB
x.x.x.x:5000/dolmstead/dart                1.12                816c55252994        40 minutes ago      184.3 MB
google/debian                                                   wheezy              11971b6377ef        11 months ago       88.23 MB

~/Documents/GitHub/dart_docker$ ./build_push.sh x.x.x.x:5000/dolmstead 1.14.0-dev.7.2
~/Documents/GitHub/dart_docker$ docker images

REPOSITORY                                                      TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
x.x.x.x:5000/dolmstead/dart-hello          1.14-dev            f45a3ff4a03f        4 minutes ago       181.2 MB
x.x.x.x:5000/dolmstead/dart-hello          1.14.0-dev.7.2      f45a3ff4a03f        4 minutes ago       181.2 MB
x.x.x.x:5000/dolmstead/dart-hello          dev                 f45a3ff4a03f        4 minutes ago       181.2 MB
x.x.x.x:5000/dolmstead/dart-hello          latest              f45a3ff4a03f        4 minutes ago       181.2 MB
x.x.x.x:5000/dolmstead/dart-runtime        1.14.0-dev.7.2      4db51bde2e2e        5 minutes ago       180.8 MB
x.x.x.x:5000/dolmstead/dart-runtime        dev                 4db51bde2e2e        5 minutes ago       180.8 MB
x.x.x.x:5000/dolmstead/dart-runtime        latest              4db51bde2e2e        5 minutes ago       180.8 MB
x.x.x.x:5000/dolmstead/dart-runtime        1.14-dev            4db51bde2e2e        5 minutes ago       180.8 MB
x.x.x.x:5000/dolmstead/dart-runtime-base   1.14-dev            b44fcb56ec84        5 minutes ago       180.8 MB
x.x.x.x:5000/dolmstead/dart-runtime-base   dev                 b44fcb56ec84        5 minutes ago       180.8 MB
x.x.x.x:5000/dolmstead/dart-runtime-base   latest              b44fcb56ec84        5 minutes ago       180.8 MB
x.x.x.x:5000/dolmstead/dart-runtime-base   1.14.0-dev.7.2      b44fcb56ec84        5 minutes ago       180.8 MB
x.x.x.x:5000/dolmstead/dart                1.14.0-dev.7.2      6922e8867e4a        5 minutes ago       180.8 MB
x.x.x.x:5000/dolmstead/dart                dev                 6922e8867e4a        5 minutes ago       180.8 MB
x.x.x.x:5000/dolmstead/dart                latest              6922e8867e4a        5 minutes ago       180.8 MB
x.x.x.x:5000/dolmstead/dart                1.14-dev            6922e8867e4a        5 minutes ago       180.8 MB
x.x.x.x:5000/dolmstead/dart-hello          1.14.0-dev.7.1      edcdacb90157        13 minutes ago      181.2 MB
x.x.x.x:5000/dolmstead/dart-runtime        1.14.0-dev.7.1      e69ee817d48a        13 minutes ago      180.8 MB
x.x.x.x:5000/dolmstead/dart-runtime-base   1.14.0-dev.7.1      0c07b34f02e6        13 minutes ago      180.8 MB
x.x.x.x:5000/dolmstead/dart                1.14.0-dev.7.1      e8ea62f91fc3        13 minutes ago      180.8 MB
<none>                                                          <none>              88da0e53dacc        20 minutes ago      88.23 MB
<none>                                                          <none>              ee69bc37fb43        28 minutes ago      88.23 MB
x.x.x.x:5000/dolmstead/dart-hello          1.13                d68104607964        32 minutes ago      181.1 MB
x.x.x.x:5000/dolmstead/dart-hello          1.13.0              d68104607964        32 minutes ago      181.1 MB
x.x.x.x:5000/dolmstead/dart-hello          1                   d68104607964        32 minutes ago      181.1 MB
x.x.x.x:5000/dolmstead/dart-runtime        1                   2e4bd918e50a        32 minutes ago      180.7 MB
x.x.x.x:5000/dolmstead/dart-runtime        1.13                2e4bd918e50a        32 minutes ago      180.7 MB
x.x.x.x:5000/dolmstead/dart-runtime        1.13.0              2e4bd918e50a        32 minutes ago      180.7 MB
x.x.x.x:5000/dolmstead/dart-runtime-base   1                   35cf4c74f81f        32 minutes ago      180.7 MB
x.x.x.x:5000/dolmstead/dart-runtime-base   1.13                35cf4c74f81f        32 minutes ago      180.7 MB
x.x.x.x:5000/dolmstead/dart-runtime-base   1.13.0              35cf4c74f81f        32 minutes ago      180.7 MB
x.x.x.x:5000/dolmstead/dart                1.13                3c7478778e5c        32 minutes ago      180.7 MB
x.x.x.x:5000/dolmstead/dart                1.13.0              3c7478778e5c        32 minutes ago      180.7 MB
x.x.x.x:5000/dolmstead/dart                1                   3c7478778e5c        32 minutes ago      180.7 MB
<none>                                                          <none>              2a931e6cfeba        38 minutes ago      88.23 MB
<none>                                                          <none>              9bd2b53571fc        40 minutes ago      88.23 MB
<none>                                                          <none>              c635b21e7f12        43 minutes ago      88.23 MB
x.x.x.x:5000/dolmstead/dart-hello          1.12                7598abb13558        50 minutes ago      184.7 MB
x.x.x.x:5000/dolmstead/dart-hello          1.12.1              7598abb13558        50 minutes ago      184.7 MB
x.x.x.x:5000/dolmstead/dart-runtime        1.12.1              26e06efbe443        50 minutes ago      184.3 MB
x.x.x.x:5000/dolmstead/dart-runtime        1.12                26e06efbe443        50 minutes ago      184.3 MB
x.x.x.x:5000/dolmstead/dart-runtime-base   1.12                91681a1b882d        50 minutes ago      184.3 MB
x.x.x.x:5000/dolmstead/dart-runtime-base   1.12.1              91681a1b882d        50 minutes ago      184.3 MB
x.x.x.x:5000/dolmstead/dart                1.12.1              816c55252994        50 minutes ago      184.3 MB
x.x.x.x:5000/dolmstead/dart                1.12                816c55252994        50 minutes ago      184.3 MB
google/debian                                                   wheezy              11971b6377ef        11 months ago       88.23 MB
```

And finally the results of hitting the registry to get the tags. So everything looks good.

A force was not required with the push on my registry only when tagging. If that's different for Google's then it might be needed,

```
x.x.x.x:5000/v1/repositories/dolmstead/dart/tags
{  
  "1":"3c7478778e5ced0243eba67d2724e98baa2a9a62b6e76cb02ecf1401c0ccf826",
  "1.12":"816c5525299489ed46a585038322a3c05d543c5e92221a3be8f0a81e1f9d754b",
  "1.12.1":"816c5525299489ed46a585038322a3c05d543c5e92221a3be8f0a81e1f9d754b",
  "1.13":"3c7478778e5ced0243eba67d2724e98baa2a9a62b6e76cb02ecf1401c0ccf826",
  "1.13.0":"3c7478778e5ced0243eba67d2724e98baa2a9a62b6e76cb02ecf1401c0ccf826",
  "1.14.0-dev.7.1":"e8ea62f91fc31f4eef002e6402fe43d2c5a8c1b8059270beeabb9490f368ee91",
  "1.14.0-dev.7.2":"6922e8867e4aa18c9c523893eae3833dd7a0a22e6ded20937e447c315d0d8b0f",
  "1.14-dev":"6922e8867e4aa18c9c523893eae3833dd7a0a22e6ded20937e447c315d0d8b0f",
  "dev":"6922e8867e4aa18c9c523893eae3833dd7a0a22e6ded20937e447c315d0d8b0f",
  "latest":"3c7478778e5ced0243eba67d2724e98baa2a9a62b6e76cb02ecf1401c0ccf826"
}
```
