### PR TITLE
Adds openssh-client to package installation

### DIFF
--- a/base/Dockerfile.template
+++ b/base/Dockerfile.template
@@ -6,7 +6,7 @@ FROM google/debian:wheezy
 ENV DART_VERSION {{VERSION}}
 
 RUN \
-  apt-get -q update && apt-get install --no-install-recommends -y -q curl git ca-certificates apt-transport-https && \
+  apt-get -q update && apt-get install --no-install-recommends -y -q curl git ca-certificates apt-transport-https openssh-client && \
   curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
   curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list && \
   curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_unstable.list > /etc/apt/sources.list.d/dart_unstable.list && \


### PR DESCRIPTION
As mentioned in issue #21 , ssh is crucial for private git dependencies when one wants to avoid having them added locally.

Therefore, this PR adds the `openssh-client` to the base docker image (and consecutively to the all the images building upon that). 

Change in image size is *less than* 1MB.