### PR TITLE
Put gnupg2 in the existing set of apt-get installs

### DIFF
--- a/base/Dockerfile.template
+++ b/base/Dockerfile.template
@@ -3,13 +3,11 @@
 # BSD-style license that can be found in the LICENSE file.
 FROM gcr.io/google-appengine/debian9
 
-# https://stackoverflow.com/questions/50757647
-RUN apt-get update && apt-get install -y gnupg2
-
 ENV DART_VERSION {{VERSION}}
 
+# gnupg2: https://stackoverflow.com/questions/50757647
 RUN \
-  apt-get -q update && apt-get install --no-install-recommends -y -q curl git ca-certificates apt-transport-https openssh-client && \
+  apt-get -q update && apt-get install --no-install-recommends -y -q gnupg2 curl git ca-certificates apt-transport-https openssh-client && \
   curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
   curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list && \
   curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_unstable.list > /etc/apt/sources.list.d/dart_unstable.list && \


### PR DESCRIPTION
Results in a 23MB smaller image

Fixes https://github.com/dart-lang/dart_docker/issues/42