### PR TITLE
[beta] Add testing repository to base image

### DIFF
--- a/base/Dockerfile.template
+++ b/base/Dockerfile.template
@@ -10,6 +10,7 @@ RUN \
   apt-get -q update && apt-get install --no-install-recommends -y -q gnupg2 curl git ca-certificates apt-transport-https openssh-client && \
   curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
   curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list && \
+  curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_testing.list > /etc/apt/sources.list.d/dart_testing.list && \
   curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_unstable.list > /etc/apt/sources.list.d/dart_unstable.list && \
   apt-get update && \
   apt-get install dart=$DART_VERSION-1 && \


### PR DESCRIPTION
Beta versions will be in the `testing` repository rather than in stable or unstable.

Related to https://github.com/dart-lang/sdk/issues/40991.