### PR TITLE
Dart browser

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,5 @@
 #   Name/Organization <email address>
 
 Google Inc.
+
+Graciliano M. Passos gracilianomp@gmail.com

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains the sources for the following
 [docker](https://docker.io) base images:
 
 - [`google/dart`][base]
+- [`google/dart-browser`][base-browser]
 - [`google/dart-runtime-base`][runtime-base]
 - [`google/dart-runtime`][runtime]
 - [`google/dart-hello`][hello]
@@ -54,6 +55,7 @@ For testing with a custom build of Dart where an already built Dart .deb file
 is used the script `build_custom.sh` can be used.
 
 [base]: https://registry.hub.docker.com/u/google/dart/
+[base-browser]: https://registry.hub.docker.com/u/google/dart-browser/
 [runtime-base]: https://registry.hub.docker.com/u/google/dart-runtime-base/
 [runtime]: https://registry.hub.docker.com/u/google/dart-runtime/
 [hello]: https://registry.hub.docker.com/u/google/dart-hello/

--- a/base-browser/.gitignore
+++ b/base-browser/.gitignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/base-browser/Dockerfile.template
+++ b/base-browser/Dockerfile.template
@@ -1,0 +1,30 @@
+# Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+#
+# Dockerfile for google/dart-runtime-base
+
+FROM {{NAMESPACE}}/dart
+
+RUN apt-get -q update && apt-get install -y firefox-esr xorg
+
+## Firefox won't run as root!
+## Adding an user that is able to use the browser:
+RUN adduser --disabled-password browser_user
+
+COPY run-as-browser_user.sh /bin/run-as-browser_user
+RUN chmod 755 /bin/run-as-browser_user && \
+  chown browser_user:root /bin/run-as-browser_user
+
+WORKDIR /app
+
+ADD --chown=browser_user:root dart_test.yaml /app/
+
+ONBUILD ADD --chown=browser_user:root pubspec.* /app/
+ONBUILD RUN run-as-browser_user pub get
+ONBUILD ADD --chown=browser_user:root . /app/
+ONBUILD RUN run-as-browser_user pub get --offline
+ONBUILD RUN chown -R browser_user:root /app/
+
+CMD ["pub", "run", "test"]
+ENTRYPOINT ["/bin/run-as-browser_user"]

--- a/base-browser/README.md
+++ b/base-browser/README.md
@@ -4,7 +4,7 @@
 [docker](https://docker.com) base image that bundles the latest version
 of the [Dart SDK](https://dart.dev), installed from
 [dart.dev](https://dart.dev/get-dart), and 
-[Firefox-ESR](https://www.mozilla.org/en-US/firefox/enterprise/),
+[Firefox-ESR](https://www.mozilla.org/),
 installed from standard `apt-get` repositories.
 
 ## Usage

--- a/base-browser/README.md
+++ b/base-browser/README.md
@@ -1,0 +1,101 @@
+# google/dart-web
+
+[`google/dart-browser`](https://hub.docker.com/r/google/dart-browser) is a
+[docker](https://docker.com) base image that bundles the latest version
+of the [Dart SDK](https://dart.dev), installed from
+[dart.dev](https://dart.dev/get-dart), and 
+[Firefox-ESR](https://www.mozilla.org/en-US/firefox/enterprise/),
+installed from standard `apt-get` repositories.
+
+## Usage
+
+To configure Docker not to copy across `pub` generated files into the Docker
+file system, create a `.dockerignore` with the following contents.
+
+    # Files and directories created by pub
+    .dart_tool/
+    .packages
+    .pub/
+    build/
+
+If you have a Web application directory with a `pubspec.yaml`,
+you can create a `Dockerfile` in the application directory with the
+following content:
+
+    FROM google/dart
+
+    WORKDIR /app
+
+    ADD pubspec.* /app/
+    RUN pub get
+    ADD . /app
+
+To build a docker image tagged with `my/web-app` run:
+
+    docker build -t my/web-app .
+
+To run this image in a container:
+
+    docker run -i -t my/web-app
+
+By default, the `ENTRYPOINT` will run `pub run test`, using the default
+platform of your project.
+
+You can pass any command to the image, and it will run the commands as
+user `browser_user`:
+
+    docker run -i -t my/web-app pub run test -p firefox
+
+## Extending this image.
+
+Is recommended to run any command using the user `browser_user`. You
+can use the bundled command `run-as-browser_user` for that:
+
+    RUN run-as-browser_user pub get
+
+Also is recommended to respect ownership using:
+
+    ADD --chown=browser_user:root some-file /app/
+    # or
+    RUN chown -R browser_user:root /app/
+
+
+
+## Test Platform
+
+To define your testing platform and the `firefox` platform, you should
+have a `dart_test.yaml` file in your project.
+ 
+By default, a `dart_test.yaml` is provided at `/app/dart_test.yaml`:
+```yaml
+concurrency: 1
+
+override_platforms:
+  chrome:
+    settings:
+      headless: true
+  firefox:
+    settings:
+      arguments: -headless
+
+define_platforms:
+  firefox-esr:
+    name: Firefox-ESR
+    extends: firefox
+    settings:
+      executable:
+        linux: firefox-esr
+
+## Uncomment if you want 'firefox' as default testing platform
+#platforms: [firefox]
+```
+
+If you need, you can select `firefox` as testing platform passing:
+
+    pub run test -p firefox
+
+## browser_user
+
+Since most browsers won't allow execution from `root`, this images has the user `browser_user`.
+
+Buy default this is the user used for execution of `ENTRYPOINT` or `CMD`.

--- a/base-browser/README.md
+++ b/base-browser/README.md
@@ -22,7 +22,7 @@ If you have a Web application directory with a `pubspec.yaml`,
 you can create a `Dockerfile` in the application directory with the
 following content:
 
-    FROM google/dart
+    FROM google/dart-browser
 
     WORKDIR /app
 

--- a/base-browser/dart_test.yaml
+++ b/base-browser/dart_test.yaml
@@ -1,0 +1,21 @@
+
+concurrency: 1
+
+override_platforms:
+  chrome:
+    settings:
+      headless: true
+  firefox:
+    settings:
+      arguments: -headless
+
+define_platforms:
+  firefox-esr:
+    name: Firefox-ESR
+    extends: firefox
+    settings:
+      executable:
+        linux: firefox-esr
+
+## Uncomment if you want 'firefox' as default testing platform
+#platforms: [firefox]

--- a/base-browser/run-as-browser_user.sh
+++ b/base-browser/run-as-browser_user.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+#
+# This script gets input ARGS as commands,
+# running them as user: browser_user
+#
+
+cd /app
+
+FULLCMD=$( echo "$@" )
+
+su -c "$FULLCMD" browser_user

--- a/build_push.sh
+++ b/build_push.sh
@@ -171,12 +171,14 @@ echo 'Pulling latest version of base image '$BASE_IMAGE
 docker pull $BASE_IMAGE
 echo 'Building...'
 build_and_tag base dart
+build_and_tag base-browser dart-browser
 build_and_tag runtime-base dart-runtime-base
 build_and_tag runtime dart-runtime
 build_and_tag hello dart-hello
 
 echo 'Pushing...'
 push_image dart
+push_image dart-browser
 push_image dart-runtime-base
 push_image dart-runtime
 push_image dart-hello

--- a/hello-browser/.dockerignore
+++ b/hello-browser/.dockerignore
@@ -1,0 +1,5 @@
+.dart_tool/
+.packages
+build/
+
+pubspec.lock

--- a/hello-browser/.gitignore
+++ b/hello-browser/.gitignore
@@ -1,0 +1,7 @@
+Dockerfile
+
+.dart_tool/
+.packages
+build/
+
+pubspec.lock

--- a/hello-browser/Dockerfile.template
+++ b/hello-browser/Dockerfile.template
@@ -1,0 +1,8 @@
+
+FROM {{NAMESPACE}}/dart-browser
+
+WORKDIR /app
+
+ADD pubspec.* /app/
+RUN pub get
+ADD . /app

--- a/hello-browser/README.md
+++ b/hello-browser/README.md
@@ -1,0 +1,24 @@
+# google/dart-hello-browser
+
+[`google/dart-hello-browser`](https://hub.docker.com/r/google/dart-hello-browser)
+is a [Docker](https://docker.io) image to show a web test inside a browser.
+
+It is based on
+[`google/dart-browser`](https://hub.docker.com/r/google/dart-browser)
+base image, that runs tests inside
+[Firefox-ESR](https://www.mozilla.org/en-US/firefox/enterprise/).
+
+## Run the Web Application tests
+
+Build and run the Docker image:
+
+    docker build -t test/dart-hello-browser .
+    
+    docker run -t test/dart-hello-browser 
+
+The default `ENTRYPOINT` will run the test at `hello_browser_test.dart`
+inside `firefox`.
+
+You can explicitly pass a command to the Docker image:
+
+    docker run -t test/dart-hello-browser pub run test -p firefox

--- a/hello-browser/README.md
+++ b/hello-browser/README.md
@@ -6,7 +6,7 @@ is a [Docker](https://docker.io) image to show a web test inside a browser.
 It is based on
 [`google/dart-browser`](https://hub.docker.com/r/google/dart-browser)
 base image, that runs tests inside
-[Firefox-ESR](https://www.mozilla.org/en-US/firefox/enterprise/).
+[Firefox-ESR](https://www.mozilla.org/).
 
 ## Run the Web Application tests
 

--- a/hello-browser/analysis_options.yaml
+++ b/hello-browser/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:pedantic/analysis_options.yaml

--- a/hello-browser/dart_test.yaml
+++ b/hello-browser/dart_test.yaml
@@ -1,0 +1,20 @@
+
+concurrency: 1
+
+override_platforms:
+  chrome:
+    settings:
+      headless: true
+  firefox:
+    settings:
+      arguments: -headless
+
+define_platforms:
+  firefox-esr:
+    name: Firefox-ESR
+    extends: firefox
+    settings:
+      executable:
+        linux: firefox-esr
+
+platforms: [firefox]

--- a/hello-browser/pubspec.yaml
+++ b/hello-browser/pubspec.yaml
@@ -1,0 +1,10 @@
+name: hello_browser
+description: Hello (Tests with Browser)
+
+dependencies:
+  pedantic: any
+
+dev_dependencies:
+  build_runner: any
+  build_web_compilers: any
+  test: any

--- a/hello-browser/test/hello_browser_test.dart
+++ b/hello-browser/test/hello_browser_test.dart
@@ -1,0 +1,22 @@
+import 'dart:html';
+
+@TestOn('browser')
+import 'package:test/test.dart';
+
+void main() {
+  group('Hello', () {
+    setUp(() {});
+
+    test('Browser Test', () {
+      var currentLocation = window.location.href;
+
+      print('----------------------------------------------------');
+      print('CURRENT BROWSER LOCATION:\n  $currentLocation');
+      print('----------------------------------------------------');
+      print('BROWSER AGENT:\n  ${ window.navigator.userAgent }');
+      print('----------------------------------------------------');
+
+      expect(currentLocation, isNotEmpty);
+    });
+  });
+}

--- a/hello-browser/web/index.css
+++ b/hello-browser/web/index.css
@@ -1,0 +1,12 @@
+body {
+  background-color: #F8F8F8;
+  font-family: 'Open Sans', sans-serif;
+  font-size: 14px;
+  font-weight: normal;
+  line-height: 1.2em;
+  margin: 15px;
+}
+
+h1, p {
+  color: #333;
+}

--- a/hello-browser/web/index.html
+++ b/hello-browser/web/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <link rel='stylesheet' href='index.css'>
+</head>
+<body>
+  <h1>Hello World!</h1>
+</body>
+</html>

--- a/hello/README.md
+++ b/hello/README.md
@@ -16,7 +16,7 @@ Run the following command to start the server application:
 ## Access the server
 
 If you are using boot2docker you need to access the server on the
-doot2docker host network. The command `boot2docker ip` will give the
+boot2docker host network. The command `boot2docker ip` will give the
 hosts address on that network.
 
     curl http://`boot2docker ip 2> /dev/null`:8080/version


### PR DESCRIPTION
Adds a Docker image `dart-browser` with a pre-installed Firefox, for headless tests.

Since is not simple to install and run a browser headless inside a docker image, and we need that for every project that have tests with a browser, I decided to share our receipt.

The main issue is that the browser won't allow execution from root user inside a docker image, and we have a simple work around for that.