### PR TITLE
fix docker hub links

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ will be build locally, but the push to hub.docker.com will fail.
 For testing with a custom build of Dart where an already built Dart .deb file
 is used the script `build_custom.sh` can be used.
 
-[base]: https://registry.hub.docker.com/u/google/dart/
-[runtime-base]: https://registry.hub.docker.com/u/google/dart-runtime-base/
-[runtime]: https://registry.hub.docker.com/u/google/dart-runtime/
-[hello]: https://registry.hub.docker.com/u/google/dart-hello/
+[base]: https://registry.hub.docker.com/r/google/dart/
+[runtime-base]: https://registry.hub.docker.com/r/google/dart-runtime-base/
+[runtime]: https://registry.hub.docker.com/r/google/dart-runtime/
+[hello]: https://registry.hub.docker.com/r/google/dart-hello/
 [1]: https://dart.dev/get-dart#install-a-debian-package


### PR DESCRIPTION
The old link (`u`) rendered an empty page, on Firefox and Chrome:

![image](https://user-images.githubusercontent.com/1633368/89739806-b3162300-da51-11ea-9e30-b1dba4dbf7ba.png)
