### PR TITLE
Add SDK constraint to hello/pubspec.yaml

### DIFF
--- a/hello/.gitignore
+++ b/hello/.gitignore
@@ -1,1 +1,3 @@
+.dart_tool
+pubspec.lock
 Dockerfile

--- a/hello/bin/server.dart
+++ b/hello/bin/server.dart
@@ -10,7 +10,7 @@ void main() {
   final port = int.tryParse(Platform.environment['PORT'] ?? '8080');
   final webFiles = new VirtualDirectory('web');
 
-  runZoned(() {
+  runZonedGuarded(() {
     HttpServer.bind('0.0.0.0', port).then((server) {
       server.listen((request) {
         if (request.uri.path == '/') {
@@ -28,7 +28,7 @@ void main() {
         }
       });
     });
-  }, onError: (e, stackTrace) {
+  }, (e, stackTrace) {
     print('Error processing request $e\n$stackTrace');
   });
 }

--- a/hello/pubspec.yaml
+++ b/hello/pubspec.yaml
@@ -3,3 +3,5 @@ description: Hello
 dependencies:
   http_server: any
   pedantic: any
+environment:
+  sdk: '>=2.10.0 <3.0.0'


### PR DESCRIPTION
Fixes #62.

* Add generated files to .gitignore.
* Replace use of deprecated method.